### PR TITLE
Support Customer Consent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
   tag:
     name: Tag the release
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-event-handler]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
   tag:
     name: Tag the release
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-event-handler]
     steps:

--- a/README.md
+++ b/README.md
@@ -57,3 +57,47 @@ In this case, we would recommend using the same anonymous ID on the cart as othe
 In the case of [Segment Analytics.js Source](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/) you can either pass your anonymous ID to Segment or let Segment generate the anonymous ID and use that.
 
 Implementing this tracking will allow anonymous orders to be associated with a registered account if the customer subsequently signs in or registers in the same browser. See [Best Practices for Identifying Users](https://segment.com/docs/connections/spec/best-practices-identify/) for more details.
+
+## Consent
+
+Segment supports a consent object "to stamp events with the end user consent preferences captured by your consent management platform (CMP)". See [Consent in Segment Connections](https://segment.com/docs/privacy/consent-management/consent-in-segment-connections/)
+
+When using this model, all events need this consent object.
+
+This connector will look for a custom field on a customer and order to get the consent object. The default field name is `consent` but this can be changed in the configuration. The field should be of type `String` and contain a JSON serialised version of the object you want to send in the Segment `consent` object.
+
+For order events, we look for the field on an order rather than a customer because orders can be anonymous (without a registered customer). You should set the content field on the cart before the order is created.
+
+Note, this connector does not create these custom fields. This is due to the fact commercetools only allows one custom type to be set on a resource at a time. So if you have existing custom types for customers and orders you will need to add it to those types or create new types.
+
+See this tutorial for details: [Use Types and Custom Fields](https://docs.commercetools.com/tutorials/custom-types)
+
+An example curl request for creating a custom field on a customer is below.
+
+```bash
+curl "https://api.europe-west1.gcp.commercetools.com/${PROJECT_KEY}/types" \
+--header "Authorization: Bearer ${BEARER_TOKEN}" \
+--header 'Content-Type: application/json' \
+--data-binary @- << DATA
+{
+  "key": "customer-consent",
+  "name": { "en": "JSON field for consent" },
+  "resourceTypeIds": ["customer"],
+  "fieldDefinitions": [
+    {
+      "type": {
+        "name": "String"
+      },
+      "name": "consent",
+      "label": {
+        "en": "Consent"
+      },
+      "required": false,
+      "inputHint": "SingleLine"
+    }
+  ]
+}
+DATA
+```
+
+The same approach can be used to create a custom field on an order.

--- a/connect.yaml
+++ b/connect.yaml
@@ -32,3 +32,7 @@ inheritAs:
         description: Locale to use for multilingual properties (e.g product names)
         required: false
         default: en-GB
+      - key: CONSENT_CUSTOM_FIELD_NAME
+        description: Custom field name on customers and orders for consent settings
+        required: false
+        default: consent

--- a/event-handler/src/lib/order-event-handler.ts
+++ b/event-handler/src/lib/order-event-handler.ts
@@ -22,7 +22,17 @@ export async function handleOrderCreated(orderId: string) {
 
     // only identify the user if they are not already in the system
     if (!customer) {
-      identifyAnonymousCustomer(order.anonymousId, order.customerEmail);
+      let consent;
+
+      if (order.custom?.fields.consent) {
+        consent = JSON.parse(order.custom.fields.consent);
+      }
+
+      identifyAnonymousCustomer(
+        order.anonymousId,
+        order.customerEmail,
+        consent
+      );
     }
   }
 

--- a/event-handler/src/lib/order-event-handler.ts
+++ b/event-handler/src/lib/order-event-handler.ts
@@ -22,16 +22,10 @@ export async function handleOrderCreated(orderId: string) {
 
     // only identify the user if they are not already in the system
     if (!customer) {
-      let consent;
-
-      if (order.custom?.fields.consent) {
-        consent = JSON.parse(order.custom.fields.consent);
-      }
-
       identifyAnonymousCustomer(
         order.anonymousId,
         order.customerEmail,
-        consent
+        order.custom?.fields.consent
       );
     }
   }

--- a/event-handler/src/lib/order-event-handler.ts
+++ b/event-handler/src/lib/order-event-handler.ts
@@ -5,9 +5,11 @@ import {
   trackOrderCompleted,
 } from './segment-analytics-service';
 import { getLogger } from '../utils/logger.utils';
+import { readConfiguration } from '../utils/config.utils';
 
 export async function handleOrderCreated(orderId: string) {
   const logger = getLogger();
+  const configuration = readConfiguration();
 
   const order = await getOrder(orderId);
 
@@ -25,7 +27,7 @@ export async function handleOrderCreated(orderId: string) {
       identifyAnonymousCustomer(
         order.anonymousId,
         order.customerEmail,
-        order.custom?.fields.consent
+        order.custom?.fields?.[configuration.consentCustomFieldName]
       );
     }
   }

--- a/event-handler/src/lib/segment-analytics-service.test.ts
+++ b/event-handler/src/lib/segment-analytics-service.test.ts
@@ -95,6 +95,48 @@ describe('sendCustomer', () => {
     });
   });
 
+  it('customer with consent field should pass consent to Segment', async () => {
+    const mockCustomer = createMockCustomer({
+      email: 'test@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      middleName: 'middle',
+      title: 'Mr',
+      dateOfBirth: '1990-11-01',
+      customerNumber: 'CN123',
+      externalId: 'EXT123',
+      isEmailVerified: true,
+      locale: 'en-US',
+      custom: {
+        type: {
+          typeId: 'type',
+          id: '8b37d6b9-8eb5-4b2e-a743-b74751c379ca',
+        },
+        fields: {
+          consent:
+            '{"categoryPreferences":{"Advertising":true,"Analytics":false,"Functional":true,"DataSharing":false}}',
+        },
+      },
+    });
+
+    identifyCustomer(mockCustomer);
+
+    expect(mockIdentify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: {
+          consent: {
+            categoryPreferences: {
+              Advertising: true,
+              Analytics: false,
+              Functional: true,
+              DataSharing: false,
+            },
+          },
+        },
+      })
+    );
+  });
+
   it('should throw an error when Segment API fails', async () => {
     const segmentError = new Error('Segment API failure');
 

--- a/event-handler/src/lib/segment-analytics-service.test.ts
+++ b/event-handler/src/lib/segment-analytics-service.test.ts
@@ -20,6 +20,7 @@ import * as orderWithUSTaxAndShippingDiscount from './test-orders/order-with-us-
 import * as orderWithUSTaxAndDiscountOnTotalPrice from './test-orders/order-with-us-tax-and-discount-on-total-price.json';
 import * as orderWithDiscountCode from './test-orders/order-with-discount-code.json';
 import * as orderWithNoShippingInfo from './test-orders/order-with-no-shipping-info.json';
+import * as orderWithConsentField from './test-orders/order-with-consent-field.json';
 import { Order } from '@commercetools/platform-sdk';
 
 jest.mock('@segment/analytics-node');
@@ -541,6 +542,27 @@ describe('trackOrderCompleted', () => {
         properties: expect.objectContaining({
           shipping: 0,
         }),
+      })
+    );
+  });
+
+  it('order with consent field should pass consent to Segment', () => {
+    const order = orderWithConsentField as Order;
+
+    trackOrderCompleted(order);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: {
+          consent: {
+            categoryPreferences: {
+              Advertising: true,
+              Analytics: false,
+              Functional: true,
+              DataSharing: false,
+            },
+          },
+        },
       })
     );
   });

--- a/event-handler/src/lib/segment-analytics-service.ts
+++ b/event-handler/src/lib/segment-analytics-service.ts
@@ -55,7 +55,11 @@ export function identifyCustomer(customer: Customer) {
   }
 }
 
-export function identifyAnonymousCustomer(anonymousId: string, email: string) {
+export function identifyAnonymousCustomer(
+  anonymousId: string,
+  email: string,
+  consent?: object
+) {
   const logger = getLogger();
 
   const analytics = createAnalytics();
@@ -64,6 +68,7 @@ export function identifyAnonymousCustomer(anonymousId: string, email: string) {
     analytics.identify({
       anonymousId,
       traits: { email },
+      context: consent ? { consent } : undefined,
     });
 
     logger.info(

--- a/event-handler/src/lib/segment-analytics-service.ts
+++ b/event-handler/src/lib/segment-analytics-service.ts
@@ -1,4 +1,4 @@
-import { Analytics } from '@segment/analytics-node';
+import { Analytics, IdentifyParams } from '@segment/analytics-node';
 import { getLogger } from '../utils/logger.utils';
 import { Customer, Order } from '@commercetools/platform-sdk';
 import { readConfiguration } from '../utils/config.utils';
@@ -20,7 +20,7 @@ export function identifyCustomer(customer: Customer) {
   try {
     // https://segment.com/docs/connections/spec/identify/#custom-traits
 
-    analytics.identify({
+    const identifyParams: IdentifyParams = {
       userId: customer.id,
       messageId: `${customer.id}-${customer.version}`,
       timestamp: customer.lastModifiedAt,
@@ -36,7 +36,17 @@ export function identifyCustomer(customer: Customer) {
         locale: customer.locale,
         createdAt: customer.createdAt,
       },
-    });
+    };
+
+    if (customer.custom?.fields.consent) {
+      const consent = JSON.parse(customer.custom.fields.consent);
+
+      identifyParams.context = {
+        consent,
+      };
+    }
+
+    analytics.identify(identifyParams);
 
     logger.info(`Customer ${customer.id} sent to Segment successfully`);
   } catch (error) {

--- a/event-handler/src/lib/segment-analytics-service.ts
+++ b/event-handler/src/lib/segment-analytics-service.ts
@@ -6,18 +6,18 @@ import {
   buildOrderCompletedTrackEvent,
   buildSegmentContext,
 } from './segment-event-builder';
+import { Configuration } from '../types/index.types';
 
-const createAnalytics = () => {
-  const configuration = readConfiguration();
-
+const createAnalytics = (configuration: Configuration) => {
   return new Analytics({
     writeKey: configuration.segmentSourceWriteKey,
   });
 };
 
 export function identifyCustomer(customer: Customer) {
+  const configuration = readConfiguration();
   const logger = getLogger();
-  const analytics = createAnalytics();
+  const analytics = createAnalytics(configuration);
 
   try {
     // https://segment.com/docs/connections/spec/identify/#custom-traits
@@ -38,7 +38,9 @@ export function identifyCustomer(customer: Customer) {
         locale: customer.locale,
         createdAt: customer.createdAt,
       },
-      context: buildSegmentContext(customer.custom?.fields?.consent),
+      context: buildSegmentContext(
+        customer.custom?.fields?.[configuration.consentCustomFieldName]
+      ),
     };
 
     analytics.identify(identifyParams);
@@ -54,8 +56,9 @@ export function identifyAnonymousCustomer(
   email: string,
   consentJson?: string
 ) {
+  const configuration = readConfiguration();
   const logger = getLogger();
-  const analytics = createAnalytics();
+  const analytics = createAnalytics(configuration);
 
   try {
     analytics.identify({
@@ -76,9 +79,10 @@ export function identifyAnonymousCustomer(
 }
 
 export function trackOrderCompleted(order: Order) {
+  const configuration = readConfiguration();
   const logger = getLogger();
 
-  const analytics = createAnalytics();
+  const analytics = createAnalytics(configuration);
 
   try {
     const event = buildOrderCompletedTrackEvent(order);

--- a/event-handler/src/lib/segment-event-builder.ts
+++ b/event-handler/src/lib/segment-event-builder.ts
@@ -27,6 +27,15 @@ export const buildOrderCompletedTrackEvent = (order: Order): TrackParams => {
   const discountTotalCents = calculateDiscountTotalCents(order);
 
   // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
+  let context;
+
+  if (order.custom?.fields.consent) {
+    const consent = JSON.parse(order.custom.fields.consent);
+
+    context = {
+      consent,
+    };
+  }
 
   return {
     userId: order.customerId as string, // need either userId or anonymousId
@@ -58,6 +67,7 @@ export const buildOrderCompletedTrackEvent = (order: Order): TrackParams => {
       products: buildProducts(order),
       currency: order.totalPrice.currencyCode,
     },
+    context,
   };
 };
 

--- a/event-handler/src/lib/segment-event-builder.ts
+++ b/event-handler/src/lib/segment-event-builder.ts
@@ -9,6 +9,13 @@ import { TrackParams } from '@segment/analytics-node';
 import _ from 'lodash';
 import { readConfiguration } from '../utils/config.utils';
 
+export const buildSegmentContext = (consent?: string) => {
+  if (consent) {
+    return { consent: JSON.parse(consent) };
+  }
+  return undefined;
+};
+
 export const buildOrderCompletedTrackEvent = (order: Order): TrackParams => {
   if (!order.taxedPrice) {
     throw new Error(`Order ${order.id} is missing taxedPrice`);
@@ -27,15 +34,6 @@ export const buildOrderCompletedTrackEvent = (order: Order): TrackParams => {
   const discountTotalCents = calculateDiscountTotalCents(order);
 
   // https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed
-  let context;
-
-  if (order.custom?.fields.consent) {
-    const consent = JSON.parse(order.custom.fields.consent);
-
-    context = {
-      consent,
-    };
-  }
 
   return {
     userId: order.customerId as string, // need either userId or anonymousId
@@ -67,7 +65,7 @@ export const buildOrderCompletedTrackEvent = (order: Order): TrackParams => {
       products: buildProducts(order),
       currency: order.totalPrice.currencyCode,
     },
-    context,
+    context: buildSegmentContext(order.custom?.fields?.consent),
   };
 };
 

--- a/event-handler/src/lib/test-orders/order-with-consent-field.json
+++ b/event-handler/src/lib/test-orders/order-with-consent-field.json
@@ -1,0 +1,459 @@
+{
+  "type": "Order",
+  "id": "88a2e78a-358c-49a2-88e0-5263296681ee",
+  "version": 1,
+  "versionModifiedAt": "2025-04-02T15:37:36.982Z",
+  "lastMessageSequenceNumber": 1,
+  "createdAt": "2025-04-02T15:37:36.961Z",
+  "lastModifiedAt": "2025-04-02T15:37:36.961Z",
+  "lastModifiedBy": {
+    "clientId": "8RA_fQF445uG352YARWBuN5I",
+    "isPlatformClient": false
+  },
+  "createdBy": {
+    "clientId": "8RA_fQF445uG352YARWBuN5I",
+    "isPlatformClient": false
+  },
+  "anonymousId": "9da67d3a-eaf8-41ed-8d6e-9b0a64ef81f0",
+  "totalPrice": {
+    "type": "centPrecision",
+    "currencyCode": "EUR",
+    "centAmount": 33399,
+    "fractionDigits": 2
+  },
+  "taxedPrice": {
+    "totalNet": {
+      "type": "centPrecision",
+      "currencyCode": "EUR",
+      "centAmount": 28066,
+      "fractionDigits": 2
+    },
+    "totalGross": {
+      "type": "centPrecision",
+      "currencyCode": "EUR",
+      "centAmount": 33399,
+      "fractionDigits": 2
+    },
+    "taxPortions": [
+      {
+        "rate": 0.19,
+        "amount": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 5333,
+          "fractionDigits": 2
+        },
+        "name": "Standard VAT for Germany"
+      }
+    ],
+    "totalTax": {
+      "type": "centPrecision",
+      "currencyCode": "EUR",
+      "centAmount": 5333,
+      "fractionDigits": 2
+    }
+  },
+  "country": "DE",
+  "orderState": "Open",
+  "syncInfo": [],
+  "returnInfo": [],
+  "taxMode": "Platform",
+  "inventoryMode": "None",
+  "taxRoundingMode": "HalfEven",
+  "taxCalculationMode": "LineItemLevel",
+  "origin": "Customer",
+  "shippingMode": "Single",
+  "shippingAddress": {
+    "title": "My Address",
+    "salutation": "Mr.",
+    "firstName": "Example",
+    "lastName": "Person",
+    "streetName": "Example Street",
+    "streetNumber": "4711",
+    "additionalStreetInfo": "Backhouse",
+    "postalCode": "80933",
+    "city": "Exemplary City",
+    "region": "Exemplary Region",
+    "state": "Exemplary State",
+    "country": "DE",
+    "company": "My Company Name",
+    "department": "Sales",
+    "building": "Hightower 1",
+    "apartment": "247",
+    "pOBox": "2471",
+    "phone": "+49 89 12345678",
+    "mobile": "+49 171 2345678",
+    "email": "email@example.com",
+    "fax": "+49 89 12345679",
+    "additionalAddressInfo": "no additional Info",
+    "externalId": "Information not needed",
+    "key": "address-1"
+  },
+  "shipping": [],
+  "discountTypeCombination": { "type": "Stacking" },
+  "lineItems": [
+    {
+      "id": "b78062d6-f0e2-47c8-9403-c662f0686aaf",
+      "productId": "a312c826-9218-4f1b-81e3-25d07e3e6754",
+      "productKey": "rye-whiskey-glass",
+      "name": {
+        "en-US": "Rye Whiskey Glass",
+        "en-GB": "Rye Whiskey Glass",
+        "de-DE": "Rye-Whiskyglas"
+      },
+      "productType": {
+        "typeId": "product-type",
+        "id": "d1a88a56-c368-453c-b5d1-73f5389fd898"
+      },
+      "productSlug": {
+        "en-US": "rye-whiskey-glass",
+        "en-GB": "rye-whiskey-glass",
+        "de-DE": "roggen-whisky-glas"
+      },
+      "variant": {
+        "id": 1,
+        "sku": "RWG-09",
+        "key": "ryeWhiskeyGlass01",
+        "prices": [
+          {
+            "id": "4dd031fc-7caf-41ad-be94-fe6fbc007b8a",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 3499,
+              "fractionDigits": 2
+            },
+            "key": "3499EUR",
+            "country": "DE"
+          },
+          {
+            "id": "02b89850-918a-4795-ad71-54d75e5400cd",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "GBP",
+              "centAmount": 3499,
+              "fractionDigits": 2
+            },
+            "key": "3499GBP",
+            "country": "GB"
+          },
+          {
+            "id": "93a47a9a-fc01-490e-a74d-ccd770f7b3a0",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "USD",
+              "centAmount": 3499,
+              "fractionDigits": 2
+            },
+            "key": "3499USD",
+            "country": "US"
+          }
+        ],
+        "images": [
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Rye_Whiskey_Glass-1.1.jpeg",
+            "dimensions": { "w": 2848, "h": 2990 }
+          },
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Rye_Whiskey_Glass-1.2.jpeg",
+            "dimensions": { "w": 2632, "h": 2268 }
+          }
+        ],
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "en-GB": "- Set includes 6 glasses",
+              "en-US": "- Set includes 6 glasses",
+              "de-DE": "- Das Set enthält 6 Gläser"
+            }
+          },
+          {
+            "name": "color",
+            "value": {
+              "en-GB": "Transparent:transparent",
+              "de-DE": "Transparent:transparent",
+              "en-US": "Transparent:transparent"
+            }
+          },
+          {
+            "name": "finish",
+            "value": {
+              "en-GB": "Glass:transparent",
+              "de-DE": "Glas:transparent",
+              "en-US": "Glass:transparent"
+            }
+          }
+        ],
+        "assets": [],
+        "availability": {
+          "isOnStock": true,
+          "availableQuantity": 100,
+          "version": 1,
+          "id": "5a515e9a-bf58-4cee-910b-d9ded6780d88"
+        }
+      },
+      "price": {
+        "id": "4dd031fc-7caf-41ad-be94-fe6fbc007b8a",
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 3499,
+          "fractionDigits": 2
+        },
+        "key": "3499EUR",
+        "country": "DE"
+      },
+      "quantity": 1,
+      "discountedPricePerQuantity": [],
+      "taxRate": {
+        "name": "Standard VAT for Germany",
+        "amount": 0.19,
+        "includedInPrice": true,
+        "country": "DE",
+        "id": "_1kYzUHR",
+        "key": "vat-standard-de",
+        "subRates": []
+      },
+      "perMethodTaxRate": [],
+      "addedAt": "2025-04-02T15:37:36.593Z",
+      "lastModifiedAt": "2025-04-02T15:37:36.593Z",
+      "state": [
+        {
+          "quantity": 1,
+          "state": {
+            "typeId": "state",
+            "id": "23a7d77f-c6a0-4876-b763-a5d8a27f9549"
+          }
+        }
+      ],
+      "priceMode": "Platform",
+      "lineItemMode": "Standard",
+      "totalPrice": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 3499,
+        "fractionDigits": 2
+      },
+      "taxedPrice": {
+        "totalNet": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 2940,
+          "fractionDigits": 2
+        },
+        "totalGross": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 3499,
+          "fractionDigits": 2
+        },
+        "taxPortions": [
+          {
+            "rate": 0.19,
+            "amount": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 559,
+              "fractionDigits": 2
+            },
+            "name": "Standard VAT for Germany"
+          }
+        ],
+        "totalTax": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 559,
+          "fractionDigits": 2
+        }
+      },
+      "taxedPricePortions": []
+    },
+    {
+      "id": "57aa9bf6-fe6b-49c6-8a96-c1887b519b75",
+      "productId": "7a9f0aee-4193-4700-b3d6-33c7531d2cdd",
+      "productKey": "ivory-lounge-chair",
+      "name": {
+        "en-US": "Ivory Lounge Chair",
+        "en-GB": "Ivory Lounge Chair",
+        "de-DE": "Elfenbein Lounge Stuhl"
+      },
+      "productType": {
+        "typeId": "product-type",
+        "id": "d1a88a56-c368-453c-b5d1-73f5389fd898"
+      },
+      "productSlug": {
+        "en-US": "ivory-lounge-chair",
+        "en-GB": "ivory-lounge-chair",
+        "de-DE": "elfenbein-lounge-stuhl"
+      },
+      "variant": {
+        "id": 1,
+        "sku": "ILC-01",
+        "key": "ivoryLoungeChair01",
+        "prices": [
+          {
+            "id": "dc145042-da80-4b07-9808-0533501ec948",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 29900,
+              "fractionDigits": 2
+            },
+            "key": "29900EUR",
+            "country": "DE"
+          },
+          {
+            "id": "cc66decc-f1ca-4d88-bea6-917884cfca65",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "GBP",
+              "centAmount": 29900,
+              "fractionDigits": 2
+            },
+            "key": "29900GBP",
+            "country": "GB"
+          },
+          {
+            "id": "cd211f2b-4f3d-419f-a29c-9d23329b483c",
+            "value": {
+              "type": "centPrecision",
+              "currencyCode": "USD",
+              "centAmount": 29900,
+              "fractionDigits": 2
+            },
+            "key": "29900USD",
+            "country": "US"
+          }
+        ],
+        "images": [
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Ivory_Lounge_Chair-1.1.jpeg",
+            "dimensions": { "w": 5500, "h": 4400 }
+          },
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Ivory_Lounge_Chair-1.2.jpeg",
+            "dimensions": { "w": 3375, "h": 4500 }
+          },
+          {
+            "url": "https://storage.googleapis.com/merchant-center-europe/sample-data/b2c-lifestyle/Ivory_Lounge_Chair-1.3.jpeg",
+            "dimensions": { "w": 3750, "h": 5000 }
+          }
+        ],
+        "attributes": [
+          {
+            "name": "productspec",
+            "value": {
+              "en-GB": "- Dry clean only\n- Assembly included in delivery",
+              "de-DE": "- Nur chemische Reinigung\n- Montage im Lieferumfang enthalten",
+              "en-US": "- Dry clean only\n- Assembly included in delivery"
+            }
+          },
+          {
+            "name": "color",
+            "value": {
+              "en-GB": "Ivory:#FFFFF0",
+              "de-DE": "Elfenbein:#FFFFF0",
+              "en-US": "Ivory:#FFFFF0"
+            }
+          }
+        ],
+        "assets": [],
+        "availability": {
+          "isOnStock": true,
+          "availableQuantity": 100,
+          "version": 1,
+          "id": "e6ff0566-471a-489c-95b1-d90287f89ce4"
+        }
+      },
+      "price": {
+        "id": "dc145042-da80-4b07-9808-0533501ec948",
+        "value": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 29900,
+          "fractionDigits": 2
+        },
+        "key": "29900EUR",
+        "country": "DE"
+      },
+      "quantity": 1,
+      "discountedPricePerQuantity": [],
+      "taxRate": {
+        "name": "Standard VAT for Germany",
+        "amount": 0.19,
+        "includedInPrice": true,
+        "country": "DE",
+        "id": "_1kYzUHR",
+        "key": "vat-standard-de",
+        "subRates": []
+      },
+      "perMethodTaxRate": [],
+      "addedAt": "2025-04-02T15:37:36.593Z",
+      "lastModifiedAt": "2025-04-02T15:37:36.593Z",
+      "state": [
+        {
+          "quantity": 1,
+          "state": {
+            "typeId": "state",
+            "id": "23a7d77f-c6a0-4876-b763-a5d8a27f9549"
+          }
+        }
+      ],
+      "priceMode": "Platform",
+      "lineItemMode": "Standard",
+      "totalPrice": {
+        "type": "centPrecision",
+        "currencyCode": "EUR",
+        "centAmount": 29900,
+        "fractionDigits": 2
+      },
+      "taxedPrice": {
+        "totalNet": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 25126,
+          "fractionDigits": 2
+        },
+        "totalGross": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 29900,
+          "fractionDigits": 2
+        },
+        "taxPortions": [
+          {
+            "rate": 0.19,
+            "amount": {
+              "type": "centPrecision",
+              "currencyCode": "EUR",
+              "centAmount": 4774,
+              "fractionDigits": 2
+            },
+            "name": "Standard VAT for Germany"
+          }
+        ],
+        "totalTax": {
+          "type": "centPrecision",
+          "currencyCode": "EUR",
+          "centAmount": 4774,
+          "fractionDigits": 2
+        }
+      },
+      "taxedPricePortions": []
+    }
+  ],
+  "customLineItems": [],
+  "transactionFee": true,
+  "discountCodes": [],
+  "directDiscounts": [],
+  "cart": { "typeId": "cart", "id": "4424c81b-81bf-4390-8af7-2cf1519660b0" },
+  "custom": {
+    "type": { "typeId": "type", "id": "f3674bec-642c-4182-a608-849cc1ddf60b" },
+    "fields": {
+      "consent": "{\"categoryPreferences\":{\"Advertising\":true,\"Analytics\":false,\"Functional\":true,\"DataSharing\":false}}"
+    }
+  },
+  "itemShippingAddresses": [],
+  "refusedGifts": []
+}

--- a/event-handler/src/test-helpers/test-config-helper.ts
+++ b/event-handler/src/test-helpers/test-config-helper.ts
@@ -10,5 +10,6 @@ export const getConfig = (): Configuration => {
     segmentSourceWriteKey: 'mock-segment-write-key',
     segmentPublicApiToken: 'mock-segment-public-api-token',
     locale: 'en-GB',
+    consentCustomFieldName: 'consent',
   };
 };

--- a/event-handler/src/types/index.types.ts
+++ b/event-handler/src/types/index.types.ts
@@ -7,6 +7,7 @@ export interface Configuration {
   segmentSourceWriteKey: string;
   segmentPublicApiToken?: string;
   locale: string;
+  consentCustomFieldName: string;
   otlpExporterEndpoint?: string;
   otlpExporterEndpointApiKey?: string;
 }

--- a/event-handler/src/utils/config.utils.test.ts
+++ b/event-handler/src/utils/config.utils.test.ts
@@ -23,6 +23,7 @@ describe('readConfiguration', () => {
     process.env.CTP_API_URL = testConfig.apiUrl;
     process.env.SEGMENT_SOURCE_WRITE_KEY = testConfig.segmentSourceWriteKey;
     process.env.LOCALE = 'en-US';
+    process.env.CONSENT_CUSTOM_FIELD_NAME = 'consentCustomFieldName';
 
     const config = readConfiguration();
 
@@ -34,6 +35,7 @@ describe('readConfiguration', () => {
       apiUrl: testConfig.apiUrl,
       segmentSourceWriteKey: testConfig.segmentSourceWriteKey,
       locale: 'en-US',
+      consentCustomFieldName: 'consentCustomFieldName',
     });
   });
 

--- a/event-handler/src/utils/config.utils.test.ts
+++ b/event-handler/src/utils/config.utils.test.ts
@@ -16,12 +16,7 @@ describe('readConfiguration', () => {
   it('should return the configuration when all environment variables are valid', () => {
     const testConfig = getConfig();
 
-    process.env.CTP_CLIENT_ID = testConfig.clientId;
-    process.env.CTP_CLIENT_SECRET = testConfig.clientSecret;
-    process.env.CTP_PROJECT_KEY = testConfig.projectKey;
-    process.env.CTP_AUTH_URL = testConfig.authUrl;
-    process.env.CTP_API_URL = testConfig.apiUrl;
-    process.env.SEGMENT_SOURCE_WRITE_KEY = testConfig.segmentSourceWriteKey;
+    setMinimumValidEnvVars(testConfig);
     process.env.LOCALE = 'en-US';
     process.env.CONSENT_CUSTOM_FIELD_NAME = 'consentCustomFieldName';
 
@@ -50,17 +45,31 @@ describe('readConfiguration', () => {
   it('should use default locale when LOCALE is not set', () => {
     const testConfig = getConfig();
 
-    process.env.CTP_CLIENT_ID = testConfig.clientId;
-    process.env.CTP_CLIENT_SECRET = testConfig.clientSecret;
-    process.env.CTP_PROJECT_KEY = testConfig.projectKey;
-    process.env.CTP_AUTH_URL = testConfig.authUrl;
-    process.env.CTP_API_URL = testConfig.apiUrl;
-    process.env.SEGMENT_SOURCE_WRITE_KEY = testConfig.segmentSourceWriteKey;
-
+    setMinimumValidEnvVars(testConfig);
     delete process.env.LOCALE;
 
     const config = readConfiguration();
 
     expect(config.locale).toBe('en-GB');
   });
+
+  it('should use default consent custom field name when not set', () => {
+    const testConfig = getConfig();
+
+    setMinimumValidEnvVars(testConfig);
+    delete process.env.CONSENT_CUSTOM_FIELD_NAME;
+
+    const config = readConfiguration();
+
+    expect(config.consentCustomFieldName).toBe('consent');
+  });
 });
+
+const setMinimumValidEnvVars = (testConfig: ReturnType<typeof getConfig>) => {
+  process.env.CTP_CLIENT_ID = testConfig.clientId;
+  process.env.CTP_CLIENT_SECRET = testConfig.clientSecret;
+  process.env.CTP_PROJECT_KEY = testConfig.projectKey;
+  process.env.CTP_AUTH_URL = testConfig.authUrl;
+  process.env.CTP_API_URL = testConfig.apiUrl;
+  process.env.SEGMENT_SOURCE_WRITE_KEY = testConfig.segmentSourceWriteKey;
+};

--- a/event-handler/src/utils/config.utils.ts
+++ b/event-handler/src/utils/config.utils.ts
@@ -16,6 +16,7 @@ export const readConfiguration = (): Configuration => {
     otlpExporterEndpointApiKey: process.env
       .OTEL_EXPORTER_OTLP_ENDPOINT_API_KEY as string,
     locale: process.env.LOCALE || 'en-GB',
+    consentCustomFieldName: process.env.CONSENT_CUSTOM_FIELD_NAME || 'consent',
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);

--- a/event-handler/src/utils/config.utils.ts
+++ b/event-handler/src/utils/config.utils.ts
@@ -15,8 +15,8 @@ export const readConfiguration = (): Configuration => {
     otlpExporterEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
     otlpExporterEndpointApiKey: process.env
       .OTEL_EXPORTER_OTLP_ENDPOINT_API_KEY as string,
-    locale: process.env.LOCALE || 'en-GB',
-    consentCustomFieldName: process.env.CONSENT_CUSTOM_FIELD_NAME || 'consent',
+    locale: process.env.LOCALE ?? 'en-GB',
+    consentCustomFieldName: process.env.CONSENT_CUSTOM_FIELD_NAME ?? 'consent',
   };
 
   const validationErrors = getValidateMessages(envValidators, envVars);


### PR DESCRIPTION
Support passing the content object to Segment: [Consent in Segment Connections](https://segment.com/docs/privacy/consent-management/consent-in-segment-connections/)

We look for a custom field on users and orders and if it exists pass it to Segment. This custom field name can be overridden in the configuration. The field is a JSON serialised version of the object.

Since we're in a connector here, we don't have access to any cookies/settings on the website/app the user is using to create orders. As a result, we need the data to be set on a customer or order so we have access to it.