### PR TITLE
Change Segment Delete to use Fetch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
   tag:
     name: Tag the release
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-event-handler]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
   tag:
     name: Tag the release
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-event-handler]
     steps:

--- a/connect.yaml
+++ b/connect.yaml
@@ -15,6 +15,10 @@ deployAs:
           description: Segment Public API host
           required: false
           default: https://api.segmentapis.com
+        - key: SEGMENT_ANALYTICS_HOST
+          description: Segment Analytics host
+          required: false
+          default: https://api.segment.io
 inheritAs:
   apiClient:
     scopes:

--- a/connect.yaml
+++ b/connect.yaml
@@ -6,19 +6,15 @@ deployAs:
       postDeploy: yarn install && yarn build && yarn connector:post-deploy
       preUndeploy: yarn install && yarn build && yarn connector:pre-undeploy
     configuration:
-      standardConfiguration: []
+      standardConfiguration:
+        - key: SEGMENT_PUBLIC_API_HOST
+          description: Segment Public API host (for user deletion/suppression)
+          required: false
+          default: https://api.segmentapis.com
       securedConfiguration:
         - key: SEGMENT_PUBLIC_API_TOKEN
           description: Segment Public API Token (for user deletion/suppression)
           required: false
-        - key: SEGMENT_PUBLIC_API_HOST
-          description: Segment Public API host
-          required: false
-          default: https://api.segmentapis.com
-        - key: SEGMENT_ANALYTICS_HOST
-          description: Segment Analytics host
-          required: false
-          default: https://api.segment.io
 inheritAs:
   apiClient:
     scopes:
@@ -33,6 +29,10 @@ inheritAs:
         description: OpenTelemetry OTLP exporter API key
         required: false
     standardConfiguration:
+      - key: SEGMENT_ANALYTICS_HOST
+        description: Segment Analytics host
+        required: false
+        default: https://api.segment.io
       - key: OTEL_EXPORTER_OTLP_ENDPOINT
         description: OpenTelemetry OTLP exporter endpoint
         required: false

--- a/connect.yaml
+++ b/connect.yaml
@@ -11,6 +11,10 @@ deployAs:
         - key: SEGMENT_PUBLIC_API_TOKEN
           description: Segment Public API Token (for user deletion/suppression)
           required: false
+        - key: SEGMENT_PUBLIC_API_HOST
+          description: Segment Public API host
+          required: false
+          default: https://api.segmentapis.com
 inheritAs:
   apiClient:
     scopes:

--- a/connect.yaml
+++ b/connect.yaml
@@ -9,12 +9,10 @@ deployAs:
       standardConfiguration:
         - key: SEGMENT_PUBLIC_API_HOST
           description: Segment Public API host (for user deletion/suppression)
-          required: false
           default: https://api.segmentapis.com
       securedConfiguration:
         - key: SEGMENT_PUBLIC_API_TOKEN
           description: Segment Public API Token (for user deletion/suppression)
-          required: false
 inheritAs:
   apiClient:
     scopes:
@@ -25,22 +23,18 @@ inheritAs:
     securedConfiguration:
       - key: SEGMENT_SOURCE_WRITE_KEY
         description: The write key from your Twilio Segment Source
+        required: true
       - key: OTEL_EXPORTER_OTLP_ENDPOINT_API_KEY
         description: OpenTelemetry OTLP exporter API key
-        required: false
     standardConfiguration:
       - key: SEGMENT_ANALYTICS_HOST
         description: Segment Analytics host
-        required: false
         default: https://api.segment.io
       - key: OTEL_EXPORTER_OTLP_ENDPOINT
         description: OpenTelemetry OTLP exporter endpoint
-        required: false
       - key: LOCALE
         description: Locale to use for multilingual properties (e.g product names)
-        required: false
         default: en-GB
       - key: CONSENT_CUSTOM_FIELD_NAME
         description: Custom field name on customers and orders for consent settings
-        required: false
         default: consent

--- a/event-handler/package.json
+++ b/event-handler/package.json
@@ -53,6 +53,7 @@
     "decimal.js": "^10.5.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "jest-fetch-mock": "^3.0.3",
     "lodash": "^4.17.21",
     "validator": "^13.12.0"
   }

--- a/event-handler/package.json
+++ b/event-handler/package.json
@@ -47,7 +47,6 @@
     "@opentelemetry/sdk-logs": "^0.55.0",
     "@opentelemetry/winston-transport": "^0.8.0",
     "@segment/analytics-node": "^2.2.1",
-    "@segment/public-api-sdk-typescript": "^58.0.1-b11060",
     "body-parser": "^1.20.3",
     "common": "link:../common",
     "decimal.js": "^10.5.0",

--- a/event-handler/package.json
+++ b/event-handler/package.json
@@ -29,6 +29,7 @@
     "eslint": "^9.23.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "supertest": "^7.1.0",
@@ -52,7 +53,6 @@
     "decimal.js": "^10.5.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
-    "jest-fetch-mock": "^3.0.3",
     "lodash": "^4.17.21",
     "validator": "^13.12.0"
   }

--- a/event-handler/src/lib/segment-analytics-service.ts
+++ b/event-handler/src/lib/segment-analytics-service.ts
@@ -11,6 +11,7 @@ import { Configuration } from '../types/index.types';
 const createAnalytics = (configuration: Configuration) => {
   return new Analytics({
     writeKey: configuration.segmentSourceWriteKey,
+    host: configuration.segmentAnalyticsHost,
   });
 };
 

--- a/event-handler/src/lib/segment-user-deletion-service.ts
+++ b/event-handler/src/lib/segment-user-deletion-service.ts
@@ -12,18 +12,21 @@ export const deleteUser = async (userId: string) => {
     return;
   }
 
-  const response = await fetch('https://api.segmentapis.com/regulations', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${configuration.segmentPublicApiToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      regulationType: 'SUPPRESS_WITH_DELETE',
-      subjectType: 'USER_ID',
-      subjectIds: [userId],
-    }),
-  });
+  const response = await fetch(
+    `${configuration.segmentPublicApiHost}/regulations`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${configuration.segmentPublicApiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        regulationType: 'SUPPRESS_WITH_DELETE',
+        subjectType: 'USER_ID',
+        subjectIds: [userId],
+      }),
+    }
+  );
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/event-handler/src/test-helpers/test-config-helper.ts
+++ b/event-handler/src/test-helpers/test-config-helper.ts
@@ -9,6 +9,7 @@ export const getConfig = (): Configuration => {
     apiUrl: 'https://api.example.com',
     segmentSourceWriteKey: 'mock-segment-write-key',
     segmentPublicApiToken: 'mock-segment-public-api-token',
+    segmentPublicApiHost: 'https://api.segmentapis.com',
     locale: 'en-GB',
     consentCustomFieldName: 'consent',
   };

--- a/event-handler/src/test-helpers/test-config-helper.ts
+++ b/event-handler/src/test-helpers/test-config-helper.ts
@@ -8,6 +8,7 @@ export const getConfig = (): Configuration => {
     authUrl: 'https://auth.example.com',
     apiUrl: 'https://api.example.com',
     segmentSourceWriteKey: 'mock-segment-write-key',
+    segmentAnalyticsHost: 'https://api.segment.io',
     segmentPublicApiToken: 'mock-segment-public-api-token',
     segmentPublicApiHost: 'https://api.segmentapis.com',
     locale: 'en-GB',

--- a/event-handler/src/tests/event-handler.test.ts
+++ b/event-handler/src/tests/event-handler.test.ts
@@ -10,7 +10,6 @@ import fetchMock from 'jest-fetch-mock';
 jest.mock('../client/create.client');
 jest.mock('@segment/analytics-node');
 jest.mock('../utils/config.utils');
-jest.mock('@segment/public-api-sdk-typescript');
 
 fetchMock.enableMocks();
 

--- a/event-handler/src/tests/event-handler.test.ts
+++ b/event-handler/src/tests/event-handler.test.ts
@@ -5,15 +5,14 @@ import { createApiRoot } from '../client/create.client';
 import { Analytics } from '@segment/analytics-node';
 import { Order } from '@commercetools/platform-sdk';
 import * as testOrder from '../lib/test-orders/order-with-us-tax.json';
-import {
-  configureApis,
-  CreateWorkspaceRegulationV1Input,
-} from '@segment/public-api-sdk-typescript';
+import fetchMock from 'jest-fetch-mock';
 
 jest.mock('../client/create.client');
 jest.mock('@segment/analytics-node');
 jest.mock('../utils/config.utils');
 jest.mock('@segment/public-api-sdk-typescript');
+
+fetchMock.enableMocks();
 
 const mockIdentify = jest.fn();
 const mockTrack = jest.fn();
@@ -27,6 +26,7 @@ const mockGetCustomer = jest.fn().mockResolvedValue({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  fetchMock.resetMocks();
 
   (Analytics as jest.Mock).mockImplementation(() => ({
     identify: mockIdentify,
@@ -91,15 +91,12 @@ it('should handle customer updated event', async () => {
 });
 
 it('should handle customer deleted event', async () => {
-  const mockCreateWorkspaceRegulation = jest.fn();
-
-  (configureApis as jest.Mock).mockReturnValue({
-    deletionAndSuppresion: {
-      createWorkspaceRegulation: mockCreateWorkspaceRegulation,
-    },
-  });
-
   const customerId = '871ebaf7-736d-4fc4-9782-4c25101df9f7';
+
+  fetchMock.mockResponseOnce(
+    JSON.stringify({ regulateId: 'regulate-id-123' }),
+    { status: 200 }
+  );
 
   await request(app)
     .post('/')
@@ -118,12 +115,21 @@ it('should handle customer deleted event', async () => {
     })
     .expect(204);
 
-  expect(mockCreateWorkspaceRegulation).toHaveBeenCalledWith({
-    regulationType:
-      CreateWorkspaceRegulationV1Input.RegulationTypeEnum.SUPPRESS_WITH_DELETE,
-    subjectType: CreateWorkspaceRegulationV1Input.SubjectTypeEnum.USER_ID,
-    subjectIds: [customerId],
-  });
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://api.segmentapis.com/regulations',
+    expect.objectContaining({
+      method: 'POST',
+      headers: {
+        Authorization: expect.stringContaining('Bearer'),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        regulationType: 'SUPPRESS_WITH_DELETE',
+        subjectType: 'USER_ID',
+        subjectIds: [customerId],
+      }),
+    })
+  );
 });
 
 it('should track order created event for registered user', async () => {

--- a/event-handler/src/types/index.types.ts
+++ b/event-handler/src/types/index.types.ts
@@ -6,6 +6,7 @@ export interface Configuration {
   apiUrl: string;
   segmentSourceWriteKey: string;
   segmentPublicApiToken?: string;
+  segmentPublicApiHost: string;
   locale: string;
   consentCustomFieldName: string;
   otlpExporterEndpoint?: string;

--- a/event-handler/src/types/index.types.ts
+++ b/event-handler/src/types/index.types.ts
@@ -4,10 +4,10 @@ export interface Configuration {
   projectKey: string;
   authUrl: string;
   apiUrl: string;
-  segmentSourceWriteKey: string;
-  segmentPublicApiToken?: string;
-  segmentPublicApiHost: string;
   segmentAnalyticsHost: string;
+  segmentSourceWriteKey: string;
+  segmentPublicApiHost: string;
+  segmentPublicApiToken?: string;
   locale: string;
   consentCustomFieldName: string;
   otlpExporterEndpoint?: string;

--- a/event-handler/src/types/index.types.ts
+++ b/event-handler/src/types/index.types.ts
@@ -7,6 +7,7 @@ export interface Configuration {
   segmentSourceWriteKey: string;
   segmentPublicApiToken?: string;
   segmentPublicApiHost: string;
+  segmentAnalyticsHost: string;
   locale: string;
   consentCustomFieldName: string;
   otlpExporterEndpoint?: string;

--- a/event-handler/src/utils/config.utils.test.ts
+++ b/event-handler/src/utils/config.utils.test.ts
@@ -29,6 +29,7 @@ describe('readConfiguration', () => {
       authUrl: testConfig.authUrl,
       apiUrl: testConfig.apiUrl,
       segmentSourceWriteKey: testConfig.segmentSourceWriteKey,
+      segmentPublicApiHost: testConfig.segmentPublicApiHost,
       locale: 'en-US',
       consentCustomFieldName: 'consentCustomFieldName',
     });

--- a/event-handler/src/utils/config.utils.test.ts
+++ b/event-handler/src/utils/config.utils.test.ts
@@ -28,6 +28,7 @@ describe('readConfiguration', () => {
       projectKey: testConfig.projectKey,
       authUrl: testConfig.authUrl,
       apiUrl: testConfig.apiUrl,
+      segmentAnalyticsHost: testConfig.segmentAnalyticsHost,
       segmentSourceWriteKey: testConfig.segmentSourceWriteKey,
       segmentPublicApiHost: testConfig.segmentPublicApiHost,
       locale: 'en-US',

--- a/event-handler/src/utils/config.utils.ts
+++ b/event-handler/src/utils/config.utils.ts
@@ -12,6 +12,8 @@ export const readConfiguration = (): Configuration => {
     apiUrl: process.env.CTP_API_URL as string,
     segmentSourceWriteKey: process.env.SEGMENT_SOURCE_WRITE_KEY as string,
     segmentPublicApiToken: process.env.SEGMENT_PUBLIC_API_TOKEN,
+    segmentPublicApiHost:
+      process.env.SEGMENT_PUBLIC_API_HOST ?? 'https://api.segmentapis.com',
     otlpExporterEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
     otlpExporterEndpointApiKey: process.env
       .OTEL_EXPORTER_OTLP_ENDPOINT_API_KEY as string,

--- a/event-handler/src/utils/config.utils.ts
+++ b/event-handler/src/utils/config.utils.ts
@@ -14,6 +14,8 @@ export const readConfiguration = (): Configuration => {
     segmentPublicApiToken: process.env.SEGMENT_PUBLIC_API_TOKEN,
     segmentPublicApiHost:
       process.env.SEGMENT_PUBLIC_API_HOST ?? 'https://api.segmentapis.com',
+    segmentAnalyticsHost:
+      process.env.SEGMENT_ANALYTICS_HOST ?? 'https://api.segment.io',
     otlpExporterEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
     otlpExporterEndpointApiKey: process.env
       .OTEL_EXPORTER_OTLP_ENDPOINT_API_KEY as string,

--- a/event-handler/src/validators/env.validators.test.ts
+++ b/event-handler/src/validators/env.validators.test.ts
@@ -70,6 +70,18 @@ it('invalid otlpExporterEndpointApiKey should return error', () => {
   );
 });
 
+it('invalid segmentAnalyticsHost should return error', () => {
+  const validationErrors = validate({ segmentAnalyticsHost: 'invalidHost' });
+
+  expect(validationErrors).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        code: 'InvalidSegmentAnalyticsHost',
+      }),
+    ])
+  );
+});
+
 it('invalid segmentSourceWriteKey should return error', () => {
   const validationErrors = validate({ segmentSourceWriteKey: '' });
 
@@ -77,6 +89,18 @@ it('invalid segmentSourceWriteKey should return error', () => {
     expect.arrayContaining([
       expect.objectContaining({
         code: 'InvalidSegmentSourceWriteKey',
+      }),
+    ])
+  );
+});
+
+it('invalid segmentPublicApiHost should return error', () => {
+  const validationErrors = validate({ segmentPublicApiHost: 'invalidHost' });
+
+  expect(validationErrors).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        code: 'InvalidSegmentPublicApiHost',
       }),
     ])
   );

--- a/event-handler/src/validators/env.validators.ts
+++ b/event-handler/src/validators/env.validators.ts
@@ -60,6 +60,12 @@ const envValidators = [
     { min: 4, max: 128 }
   ),
 
+  standardUrl(['segmentAnalyticsHost'], {
+    code: 'InvalidSegmentAnalyticsHost',
+    message: 'SEGMENT_ANALYTICS_HOST is not a valid URL.',
+    referencedBy: 'environmentVariables',
+  }),
+
   standardString(
     ['segmentSourceWriteKey'],
     {
@@ -69,6 +75,12 @@ const envValidators = [
     },
     { min: 1, max: 128 }
   ),
+
+  standardUrl(['segmentPublicApiHost'], {
+    code: 'InvalidSegmentPublicApiHost',
+    message: 'SEGMENT_PUBLIC_API_HOST is not a valid URL.',
+    referencedBy: 'environmentVariables',
+  }),
 
   optional(standardString)(
     ['segmentPublicApiToken'],

--- a/event-handler/yarn.lock
+++ b/event-handler/yarn.lock
@@ -1065,15 +1065,6 @@
     node-fetch "^2.6.7"
     tslib "^2.4.1"
 
-"@segment/public-api-sdk-typescript@^58.0.1-b11060":
-  version "58.0.1-b11060"
-  resolved "https://registry.yarnpkg.com/@segment/public-api-sdk-typescript/-/public-api-sdk-typescript-58.0.1-b11060.tgz#ab4ce6ba6c856de8a856a6d7c7aca5e5f71a1b69"
-  integrity sha512-3iENhzx8G7yRtGaVgNvJsdqZuVjs7PrYmK9EoFQrfgGVfeT82eNdHph+/HSvdpudq1h4oGVjZPz8MaaiYbr1kQ==
-  dependencies:
-    bluebird "^3.5.0"
-    request "^2.88.2"
-    uuid "^8.3.2"
-
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1412,7 +1403,7 @@ acorn@^8.14.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
-ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1493,18 +1484,6 @@ asap@^2.0.0:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
-asn1@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
-  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
-  dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
 async@^3.2.3:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
@@ -1514,16 +1493,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
-
-aws4@^1.8.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
-  integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1597,18 +1566,6 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
-  dependencies:
-    tweetnacl "^0.14.3"
-
-bluebird@^3.5.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 body-parser@1.20.3, body-parser@^1.20.3:
   version "1.20.3"
@@ -1728,11 +1685,6 @@ caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz#c5e104d199e6f4355a898fcd995a066c7eb9bf41"
   integrity sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==
 
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
-
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1832,7 +1784,7 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1890,11 +1842,6 @@ core-js-pure@^3.30.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.41.0.tgz#349fecad168d60807a31e83c99d73d786fe80811"
   integrity sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==
 
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
-
 create-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
@@ -1923,13 +1870,6 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
-  dependencies:
-    assert-plus "^1.0.0"
 
 debug@2.6.9:
   version "2.6.9"
@@ -2021,14 +1961,6 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2345,21 +2277,6 @@ express@^4.21.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2486,11 +2403,6 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
 form-data@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
@@ -2499,15 +2411,6 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 formidable@^3.5.1:
@@ -2595,13 +2498,6 @@ get-tsconfig@^4.7.5:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
-  dependencies:
-    assert-plus "^1.0.0"
-
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -2665,19 +2561,6 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -2727,15 +2610,6 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -2852,20 +2726,10 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
-is-typedarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -3328,11 +3192,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
-
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
@@ -3353,35 +3212,15 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
-
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.4.0"
-    verror "1.10.0"
 
 keyv@^4.5.4:
   version "4.5.4"
@@ -3550,7 +3389,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -3653,11 +3492,6 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-inspect@^1.13.3:
   version "1.13.4"
@@ -3797,11 +3631,6 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -3882,14 +3711,7 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-psl@^1.1.28:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
-  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
-  dependencies:
-    punycode "^2.3.1"
-
-punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
+punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -3912,11 +3734,6 @@ qs@^6.11.0:
   integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
   dependencies:
     side-channel "^1.1.0"
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3956,32 +3773,6 @@ regenerator-runtime@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
-
-request@^2.88.2:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4044,7 +3835,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -4054,7 +3845,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4199,21 +3990,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
-
-sshpk@^1.7.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
-  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
 
 stack-trace@0.0.x:
   version "0.0.10"
@@ -4390,14 +4166,6 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -4443,18 +4211,6 @@ tsx@^4.19.3:
     get-tsconfig "^4.7.5"
   optionalDependencies:
     fsevents "~2.3.3"
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -4535,16 +4291,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
@@ -4563,15 +4309,6 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 walker@^1.0.8:
   version "1.0.8"

--- a/event-handler/yarn.lock
+++ b/event-handler/yarn.lock
@@ -1908,6 +1908,13 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-fetch@^3.0.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
+  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
+  dependencies:
+    node-fetch "^2.7.0"
+
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -3050,6 +3057,14 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
@@ -3610,7 +3625,7 @@ negotiator@0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-node-fetch@^2.6.7:
+node-fetch@^2.6.7, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -3827,6 +3842,11 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
Previously we were using the `@segment/public-api-sdk-typescript` library for user deletion (the Typescript examples on the API documentation page uses this). However, this has security vulnerabilities raised by Dependabot and doesn't look to be very well maintained.

I've replaced this with a basic fetch call.

I've also allowed overriding the two different Segment hosts because EU workspaces use a different host.