### PR TITLE
Update commercetools API Permissions

### DIFF
--- a/event-handler/src/client/build.client.ts
+++ b/event-handler/src/client/build.client.ts
@@ -3,11 +3,12 @@ import type {
   AuthMiddlewareOptions,
   HttpMiddlewareOptions,
 } from '@commercetools/sdk-client-v2';
-import { readConfiguration } from '../utils/config.utils';
+import { Configuration } from '../types/index.types';
 
-export const createClient = (scopes: string[]) => {
-  const configuration = readConfiguration();
-
+export const createClient = (
+  configuration: Configuration,
+  scopes: string[]
+) => {
   const httpMiddlewareOptions: HttpMiddlewareOptions = {
     host: configuration.apiUrl,
   };

--- a/event-handler/src/client/build.client.ts
+++ b/event-handler/src/client/build.client.ts
@@ -4,12 +4,8 @@ import type {
   HttpMiddlewareOptions,
 } from '@commercetools/sdk-client-v2';
 import { readConfiguration } from '../utils/config.utils';
-import { Configuration } from '../types/index.types';
 
-const getProjectScope = (configuration: Configuration, scope: string) =>
-  `${scope}:${configuration.projectKey}`;
-
-export const createClient = () => {
+export const createClient = (scopes: string[]) => {
   const configuration = readConfiguration();
 
   const httpMiddlewareOptions: HttpMiddlewareOptions = {
@@ -23,11 +19,7 @@ export const createClient = () => {
       clientId: configuration.clientId,
       clientSecret: configuration.clientSecret,
     },
-    scopes: [
-      getProjectScope(configuration, 'manage_subscriptions'),
-      getProjectScope(configuration, 'view_orders'),
-      getProjectScope(configuration, 'view_customers'),
-    ],
+    scopes,
   };
 
   return new ClientBuilder()

--- a/event-handler/src/client/create.client.ts
+++ b/event-handler/src/client/create.client.ts
@@ -7,6 +7,7 @@ import { Configuration } from '../types/index.types';
 const getProjectScope = (configuration: Configuration, scope: string) =>
   `${scope}:${configuration.projectKey}`;
 
+// used for install/uninstall - has manage_subscriptions scope
 export const createAdminApiRoot = () => {
   const configuration = readConfiguration();
 

--- a/event-handler/src/client/create.client.ts
+++ b/event-handler/src/client/create.client.ts
@@ -2,13 +2,46 @@ import { createClient } from './build.client';
 import { createApiBuilderFromCtpClient } from '@commercetools/platform-sdk';
 import { readConfiguration } from '../utils/config.utils';
 import { ByProjectKeyRequestBuilder } from '@commercetools/platform-sdk/dist/declarations/src/generated/client/by-project-key-request-builder';
+import { Configuration } from '../types/index.types';
+
+const getProjectScope = (configuration: Configuration, scope: string) =>
+  `${scope}:${configuration.projectKey}`;
+
+export const createAdminApiRoot = (
+  (root?: ByProjectKeyRequestBuilder) => () => {
+    if (root) {
+      return root;
+    }
+
+    const configuration = readConfiguration();
+
+    const scopes = [
+      getProjectScope(configuration, 'manage_subscriptions'),
+      getProjectScope(configuration, 'view_orders'),
+      getProjectScope(configuration, 'view_customers'),
+    ];
+
+    root = createApiBuilderFromCtpClient(createClient(scopes)).withProjectKey({
+      projectKey: readConfiguration().projectKey,
+    });
+
+    return root;
+  }
+)();
 
 export const createApiRoot = ((root?: ByProjectKeyRequestBuilder) => () => {
   if (root) {
     return root;
   }
 
-  root = createApiBuilderFromCtpClient(createClient()).withProjectKey({
+  const configuration = readConfiguration();
+
+  const scopes = [
+    getProjectScope(configuration, 'view_orders'),
+    getProjectScope(configuration, 'view_customers'),
+  ];
+
+  root = createApiBuilderFromCtpClient(createClient(scopes)).withProjectKey({
     projectKey: readConfiguration().projectKey,
   });
 

--- a/event-handler/src/client/create.client.ts
+++ b/event-handler/src/client/create.client.ts
@@ -7,27 +7,21 @@ import { Configuration } from '../types/index.types';
 const getProjectScope = (configuration: Configuration, scope: string) =>
   `${scope}:${configuration.projectKey}`;
 
-export const createAdminApiRoot = (
-  (root?: ByProjectKeyRequestBuilder) => () => {
-    if (root) {
-      return root;
-    }
+export const createAdminApiRoot = () => {
+  const configuration = readConfiguration();
 
-    const configuration = readConfiguration();
+  const scopes = [
+    getProjectScope(configuration, 'manage_subscriptions'),
+    getProjectScope(configuration, 'view_orders'),
+    getProjectScope(configuration, 'view_customers'),
+  ];
 
-    const scopes = [
-      getProjectScope(configuration, 'manage_subscriptions'),
-      getProjectScope(configuration, 'view_orders'),
-      getProjectScope(configuration, 'view_customers'),
-    ];
-
-    root = createApiBuilderFromCtpClient(createClient(scopes)).withProjectKey({
-      projectKey: readConfiguration().projectKey,
-    });
-
-    return root;
-  }
-)();
+  return createApiBuilderFromCtpClient(
+    createClient(configuration, scopes)
+  ).withProjectKey({
+    projectKey: configuration.projectKey,
+  });
+};
 
 export const createApiRoot = ((root?: ByProjectKeyRequestBuilder) => () => {
   if (root) {
@@ -41,8 +35,10 @@ export const createApiRoot = ((root?: ByProjectKeyRequestBuilder) => () => {
     getProjectScope(configuration, 'view_customers'),
   ];
 
-  root = createApiBuilderFromCtpClient(createClient(scopes)).withProjectKey({
-    projectKey: readConfiguration().projectKey,
+  root = createApiBuilderFromCtpClient(
+    createClient(configuration, scopes)
+  ).withProjectKey({
+    projectKey: configuration.projectKey,
   });
 
   return root;

--- a/event-handler/src/connector/post-deploy.test.ts
+++ b/event-handler/src/connector/post-deploy.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, beforeEach, jest } from '@jest/globals';
 import { run } from './post-deploy';
-import { createApiRoot } from '../client/create.client';
+import { createAdminApiRoot } from '../client/create.client';
 import type { ByProjectKeyRequestBuilder } from '@commercetools/platform-sdk';
 
 jest.mock('../client/create.client');
@@ -43,7 +43,7 @@ afterEach(() => {
 });
 
 it('should create a new subscription if none exists', async () => {
-  (createApiRoot as jest.Mock).mockReturnValue(
+  (createAdminApiRoot as jest.Mock).mockReturnValue(
     getMockApiRoot(emptyGetSubscriptionsResponse)
   );
 
@@ -63,7 +63,7 @@ it('should create a new subscription if none exists', async () => {
 });
 
 it('should update an existing subscription if one exists', async () => {
-  (createApiRoot as jest.Mock).mockReturnValue(
+  (createAdminApiRoot as jest.Mock).mockReturnValue(
     getMockApiRoot(subscriptionExistsResponse)
   );
 

--- a/event-handler/src/connector/post-deploy.ts
+++ b/event-handler/src/connector/post-deploy.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { createApiRoot } from '../client/create.client';
+import { createAdminApiRoot } from '../client/create.client';
 import { createSubscription } from './actions';
 import { getLogger } from '../utils/logger.utils';
 
@@ -12,7 +12,7 @@ async function postDeploy(properties: Map<string, unknown>): Promise<void> {
   const topicName = properties.get(CONNECT_GCP_TOPIC_NAME_KEY) as string;
   const projectId = properties.get(CONNECT_GCP_PROJECT_ID_KEY) as string;
 
-  const apiRoot = createApiRoot();
+  const apiRoot = createAdminApiRoot();
 
   await createSubscription(apiRoot, topicName, projectId);
 }

--- a/event-handler/src/connector/pre-undeploy.test.ts
+++ b/event-handler/src/connector/pre-undeploy.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, beforeEach, jest } from '@jest/globals';
 import { run } from './pre-undeploy';
-import { createApiRoot } from '../client/create.client';
+import { createAdminApiRoot } from '../client/create.client';
 import type { ByProjectKeyRequestBuilder } from '@commercetools/platform-sdk';
 
 jest.mock('../client/create.client');
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 it('should delete an existing subscription if one exists', async () => {
-  (createApiRoot as jest.Mock).mockReturnValue(
+  (createAdminApiRoot as jest.Mock).mockReturnValue(
     getMockApiRoot(subscriptionExistsResponse)
   );
 
@@ -45,7 +45,7 @@ it('should delete an existing subscription if one exists', async () => {
 });
 
 it('should not attempt to delete if no subscription exists', async () => {
-  (createApiRoot as jest.Mock).mockReturnValue(
+  (createAdminApiRoot as jest.Mock).mockReturnValue(
     getMockApiRoot(emptyGetSubscriptionsResponse)
   );
 

--- a/event-handler/src/connector/pre-undeploy.ts
+++ b/event-handler/src/connector/pre-undeploy.ts
@@ -1,12 +1,12 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { createApiRoot } from '../client/create.client';
+import { createAdminApiRoot } from '../client/create.client';
 import { deleteSubscription } from './actions';
 import { getLogger } from '../utils/logger.utils';
 
 async function preUndeploy(): Promise<void> {
-  const apiRoot = createApiRoot();
+  const apiRoot = createAdminApiRoot();
   await deleteSubscription(apiRoot);
 }
 


### PR DESCRIPTION
Update commercetools API client config so only the installation/uninstallation processes have the `manage_subscriptions` scope. This is just to limit the event-handler permissions to the minimum it needs.